### PR TITLE
Share day stats

### DIFF
--- a/assets/css/openbook.css
+++ b/assets/css/openbook.css
@@ -97,5 +97,5 @@ nav.navbar {
     background-color: #FFF;
     border: 0.5px solid #DDD;
     border-radius: 2px;
-    padding: 20px;
+    padding: 15px 15px 15px 15px;
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -50,3 +50,11 @@ window.liveSocket = liveSocket
 let vh = window.innerHeight * 0.01;
 // Then we set the value in the --vh custom property to the root of the document
 document.documentElement.style.setProperty('--vh', `${vh}px`);
+
+// Refer: https://fly.io/phoenix-files/copy-to-clipboard-with-phoenix-liveview/
+window.addEventListener("phx:copy", (event) => {
+    let text_to_copy = event.target.dataset.text_to_copy;
+    navigator.clipboard.writeText(text_to_copy).then(() => {
+        // copied.
+    })
+})

--- a/lib/iex_helpers.ex
+++ b/lib/iex_helpers.ex
@@ -27,6 +27,8 @@ defmodule IexHelpers do
       alias OpenBook.Fitness.ExerciseCategory
       alias OpenBook.Fitness.NutritionCategory
       alias OpenBook.Fitness.NutritionEntry
+      alias OpenBook.Share
+      alias OpenBook.Share.DayStatsLink
 
       :ok
     end

--- a/lib/open_book/date_helpers.ex
+++ b/lib/open_book/date_helpers.ex
@@ -1,12 +1,35 @@
 defmodule OpenBook.DateHelpers do
   @moduledoc """
-  Some misc. date helpers.
+  Some miscellaneous date helpers.
   """
 
+  @doc ~S"""
+  Get a readable date, overloaded for different formats.
+
+  ## Exmples
+
+  iex> OpenBook.DateHelpers.readable_date(~D[2022-02-02], :calendar_date)
+  "Wednesday, Feb 02"
+  """
   def readable_date(date, :calendar_date) do
     "#{Calendar.strftime(date, "%A, %b %d")}"
   end
 
+  @doc ~S"""
+  Get a readable date, overloaded for different formats.
+
+  ## Examples:
+
+    iex> today = Date.utc_today()
+    iex> OpenBook.DateHelpers.readable_date(today, today, :human_relative_lingo)
+    "today"
+    iex> yesterday = Date.add(today, -1)
+    iex> OpenBook.DateHelpers.readable_date(today, yesterday, :human_relative_lingo)
+    "yesterday"
+    iex> far_back_date = Date.add(today, -10)
+    iex> OpenBook.DateHelpers.readable_date(today, far_back_date, :human_relative_lingo)
+    OpenBook.DateHelpers.readable_date(far_back_date, :calendar_date)
+  """
   def readable_date(user_local_date, other_date, :human_relative_lingo) do
     case Date.diff(user_local_date, other_date) do
       -1 ->
@@ -23,11 +46,33 @@ defmodule OpenBook.DateHelpers do
     end
   end
 
+  @doc ~S"""
+  Return a new NaiveDateTime for the start of the passed Date/NaiveDateTime.
+
+  ## Examples
+
+  iex> OpenBook.DateHelpers.naive_start_of_day(~D[2022-02-02])
+  ~N[2022-02-02 00:00:00]
+
+  iex> OpenBook.DateHelpers.naive_start_of_day(~N[2022-01-30 11:01:01])
+  ~N[2022-01-30 00:00:00]
+  """
   def naive_start_of_day(%Date{} = date), do: NaiveDateTime.new!(date, %Time{hour: 0, minute: 0, second: 0})
 
   def naive_start_of_day(%NaiveDateTime{} = naive_date_time),
     do: naive_start_of_day(NaiveDateTime.to_date(naive_date_time))
 
+  @doc ~S"""
+  Return a new NaiveDateTime for the end of the passed Date/NaiveDateTime.
+
+  ## Examples
+
+  iex> OpenBook.DateHelpers.naive_end_of_day(~D[2022-02-02])
+  ~N[2022-02-02 23:59:59]
+
+  iex> OpenBook.DateHelpers.naive_end_of_day(~N[2022-01-30 11:01:01])
+  ~N[2022-01-30 23:59:59]
+  """
   def naive_end_of_day(%Date{} = date), do: NaiveDateTime.new!(date, %Time{hour: 23, minute: 59, second: 59})
   def naive_end_of_day(naive_date_time), do: naive_end_of_day(NaiveDateTime.to_date(naive_date_time))
 end

--- a/lib/open_book/date_helpers.ex
+++ b/lib/open_book/date_helpers.ex
@@ -3,7 +3,11 @@ defmodule OpenBook.DateHelpers do
   Some misc. date helpers.
   """
 
-  def readable_date(user_local_date, other_date, :human_relative_lingo_with_prefix) do
+  def readable_date(date, :calendar_date) do
+    "#{Calendar.strftime(date, "%A, %b %d")}"
+  end
+
+  def readable_date(user_local_date, other_date, :human_relative_lingo) do
     case Date.diff(user_local_date, other_date) do
       -1 ->
         "tomorrow"
@@ -14,9 +18,8 @@ defmodule OpenBook.DateHelpers do
       1 ->
         "yesterday"
 
-      # TODO(Arie): This can have more relative dates ("this upcoming friday") etc.
       _ ->
-        "#{Calendar.strftime(other_date, "%A, %b %d")}"
+        readable_date(other_date, :calendar_date)
     end
   end
 

--- a/lib/open_book/date_helpers.ex
+++ b/lib/open_book/date_helpers.ex
@@ -20,11 +20,11 @@ defmodule OpenBook.DateHelpers do
     end
   end
 
-  def naive_start_of_day(naive_date_time) do
-    %{naive_date_time | hour: 0, minute: 0, second: 0}
-  end
+  def naive_start_of_day(%Date{} = date), do: NaiveDateTime.new!(date, %Time{hour: 0, minute: 0, second: 0})
 
-  def naive_end_of_day(naive_date_time) do
-    %{naive_date_time | hour: 23, minute: 59, second: 59}
-  end
+  def naive_start_of_day(%NaiveDateTime{} = naive_date_time),
+    do: naive_start_of_day(NaiveDateTime.to_date(naive_date_time))
+
+  def naive_end_of_day(%Date{} = date), do: NaiveDateTime.new!(date, %Time{hour: 23, minute: 59, second: 59})
+  def naive_end_of_day(naive_date_time), do: naive_end_of_day(NaiveDateTime.to_date(naive_date_time))
 end

--- a/lib/open_book/fitness.ex
+++ b/lib/open_book/fitness.ex
@@ -102,24 +102,70 @@ defmodule OpenBook.Fitness do
 
   # Helpers
 
-  # Returns the following nested map structure:
-  #
-  # [
-  #   %{
-  #     <date> => %{
-  #       <user_id> => %{
-  #         measurement_by_exercise_category_id_and_intensity_tuple: %{
-  #           {13, :light} => 20,
-  #           {14, :intense} => 60,
-  #           {14, :light} => 20,
-  #           {21, nil} => 8
-  #         },
-  #         total_calorie_estimate: 1500
-  #       }
-  #     }
-  #   },
-  #   ...
-  # ]
+  @doc ~S"""
+  Compress the passed nutrition & exercise entries.
+
+  ## Examples
+
+  iex> OpenBook.Fitness.compress_nutrition_and_exercise_entries(%{nutrition_entries: [], exercise_entries: []})
+  %{}
+
+  iex> exercise_entries = [
+  ...>      %OpenBook.Fitness.ExerciseEntry{
+  ...>        id: 13,
+  ...>        exercise_category_id: 15,
+  ...>        user_id: 1,
+  ...>        intensity_level: :intense,
+  ...>        measurement: 90,
+  ...>        local_datetime: ~N[2023-02-28 09:52:18],
+  ...>        inserted_at: ~N[2023-02-28 17:52:18],
+  ...>        updated_at: ~N[2023-02-28 17:52:18]
+  ...>      },
+  ...>      %OpenBook.Fitness.ExerciseEntry{
+  ...>        id: 12,
+  ...>        exercise_category_id: 19,
+  ...>        user_id: 2,
+  ...>        intensity_level: :light,
+  ...>        measurement: 55,
+  ...>        local_datetime: ~N[2023-02-27 20:54:49],
+  ...>        inserted_at: ~N[2023-02-28 04:54:49],
+  ...>        updated_at: ~N[2023-02-28 04:54:49]
+  ...>      }
+  ...>  ]
+  iex> nutrition_entries = [
+  ...>      %OpenBook.Fitness.NutritionEntry{
+  ...>        id: 21,
+  ...>        nutrition_category_id: 1,
+  ...>        user_id: 1,
+  ...>        calorie_estimate: 300,
+  ...>        local_datetime: ~N[2023-02-28 16:39:29],
+  ...>        inserted_at: ~N[2023-03-01 00:39:29],
+  ...>        updated_at: ~N[2023-03-01 00:39:29]
+  ...>      },
+  ...>      %OpenBook.Fitness.NutritionEntry{
+  ...>        id: 20,
+  ...>        nutrition_category_id: 1,
+  ...>        user_id: 1,
+  ...>        calorie_estimate: 500,
+  ...>        local_datetime: ~N[2023-02-28 09:52:13],
+  ...>        inserted_at: ~N[2023-02-28 17:52:13],
+  ...>        updated_at: ~N[2023-02-28 17:52:13]
+  ...>      }
+  ...>   ]
+  iex> OpenBook.Fitness.compress_nutrition_and_exercise_entries(%{ nutrition_entries: nutrition_entries, exercise_entries: exercise_entries })
+  %{
+      ~D[2023-02-27] => %{2 => %{
+          measurement_by_exercise_category_id_and_intensity_tuple: %{{19, :light} => 55},
+          total_calorie_estimate: 0
+        }
+      },
+      ~D[2023-02-28] => %{1 => %{
+          measurement_by_exercise_category_id_and_intensity_tuple: %{{15, :intense} => 90},
+          total_calorie_estimate: 800
+        }
+      }
+  }
+  """
   def compress_nutrition_and_exercise_entries(%{
         nutrition_entries: nutrition_entries,
         exercise_entries: exercise_entries

--- a/lib/open_book/fitness.ex
+++ b/lib/open_book/fitness.ex
@@ -6,14 +6,12 @@ defmodule OpenBook.Fitness do
   alias OpenBook.Fitness.ExerciseEntry
   alias OpenBook.Fitness.NutritionCategory
   alias OpenBook.Fitness.NutritionEntry
+  alias OpenBook.HumanReadable
   alias OpenBook.LittleLogger, as: LL
   alias OpenBook.QueryBuilders, as: QB
   alias OpenBook.Repo
 
   defdelegate human_readable_nutrition_and_calorie_selection(category_name, approx_calorie_count), to: NutritionCategory
-
-  defdelegate human_readable_exercise_selection(exercise_category_name, intensity_level, exercise_measurement),
-    to: ExerciseCategory
 
   defdelegate intensity_levels(), to: ExerciseEntry
 
@@ -100,6 +98,111 @@ defmodule OpenBook.Fitness do
     from(ec in ExerciseCategory)
     |> QB.ordered_by(asc: :id)
     |> Repo.all()
+  end
+
+  # Helpers
+
+  # Returns the following nested map structure:
+  #
+  # [
+  #   %{
+  #     <date> => %{
+  #       <user_id> => %{
+  #         measurement_by_exercise_category_id_and_intensity_tuple: %{
+  #           {13, :light} => 20,
+  #           {14, :intense} => 60,
+  #           {14, :light} => 20,
+  #           {21, nil} => 8
+  #         },
+  #         total_calorie_estimate: 1500
+  #       }
+  #     }
+  #   },
+  #   ...
+  # ]
+  def compress_nutrition_and_exercise_entries(%{
+        nutrition_entries: nutrition_entries,
+        exercise_entries: exercise_entries
+      }) do
+    result = %{}
+    default_data = %{total_calorie_estimate: 0, measurement_by_exercise_category_id_and_intensity_tuple: %{}}
+
+    # Merge in nutrition entries.
+    result =
+      Enum.reduce(nutrition_entries, result, fn %{
+                                                  local_datetime: local_datetime,
+                                                  user_id: user_id,
+                                                  calorie_estimate: calorie_estimate
+                                                },
+                                                result_acc ->
+        date = NaiveDateTime.to_date(local_datetime)
+
+        update_in(result_acc, [Access.key(date, %{}), user_id], fn maybe_current_value ->
+          current_value = maybe_current_value || default_data
+          new_total_calorie_estimate = current_value.total_calorie_estimate + calorie_estimate
+
+          %{current_value | total_calorie_estimate: new_total_calorie_estimate}
+        end)
+      end)
+
+    # Merge in exercise entries.
+    result =
+      Enum.reduce(exercise_entries, result, fn %{
+                                                 local_datetime: local_datetime,
+                                                 user_id: user_id,
+                                                 exercise_category_id: exercise_category_id,
+                                                 intensity_level: intensity_level,
+                                                 measurement: measurement
+                                               },
+                                               result_acc ->
+        date = NaiveDateTime.to_date(local_datetime)
+
+        update_in(result_acc, [Access.key(date, %{}), user_id], fn maybe_current_value ->
+          current_value = maybe_current_value || default_data
+
+          new_measurement_by_exercise_category_id_and_intensity_tuple =
+            current_value.measurement_by_exercise_category_id_and_intensity_tuple
+            |> Map.put_new({exercise_category_id, intensity_level}, 0)
+            |> Map.update!({exercise_category_id, intensity_level}, fn total_measurement ->
+              total_measurement + measurement
+            end)
+
+          %{
+            current_value
+            | measurement_by_exercise_category_id_and_intensity_tuple:
+                new_measurement_by_exercise_category_id_and_intensity_tuple
+          }
+        end)
+      end)
+
+    result
+  end
+
+  def get_readable_calorie_description(compressed_nutrition_and_exercise_entries, date, user_id, who) do
+    maybe_calories = get_in(compressed_nutrition_and_exercise_entries, [date, user_id, :total_calorie_estimate])
+
+    HumanReadable.human_readable_calorie_description(who, maybe_calories)
+  end
+
+  def get_readable_exercise_description(
+        compressed_nutrition_and_exercise_entries,
+        date,
+        user_id,
+        who,
+        all_exercise_category_names_by_id
+      ) do
+    measurement_by_exercise_category_id_and_intensity_tuple =
+      get_in(compressed_nutrition_and_exercise_entries, [
+        date,
+        user_id,
+        :measurement_by_exercise_category_id_and_intensity_tuple
+      ])
+
+    HumanReadable.human_readable_exercise_description(
+      who,
+      measurement_by_exercise_category_id_and_intensity_tuple,
+      all_exercise_category_names_by_id
+    )
   end
 
   # Private

--- a/lib/open_book/fitness.ex
+++ b/lib/open_book/fitness.ex
@@ -112,47 +112,38 @@ defmodule OpenBook.Fitness do
 
   iex> exercise_entries = [
   ...>      %OpenBook.Fitness.ExerciseEntry{
-  ...>        id: 13,
   ...>        exercise_category_id: 15,
   ...>        user_id: 1,
   ...>        intensity_level: :intense,
   ...>        measurement: 90,
-  ...>        local_datetime: ~N[2023-02-28 09:52:18],
-  ...>        inserted_at: ~N[2023-02-28 17:52:18],
-  ...>        updated_at: ~N[2023-02-28 17:52:18]
+  ...>        local_datetime: ~N[2023-02-28 09:52:18]
   ...>      },
   ...>      %OpenBook.Fitness.ExerciseEntry{
-  ...>        id: 12,
   ...>        exercise_category_id: 19,
   ...>        user_id: 2,
   ...>        intensity_level: :light,
   ...>        measurement: 55,
-  ...>        local_datetime: ~N[2023-02-27 20:54:49],
-  ...>        inserted_at: ~N[2023-02-28 04:54:49],
-  ...>        updated_at: ~N[2023-02-28 04:54:49]
+  ...>        local_datetime: ~N[2023-02-27 20:54:49]
   ...>      }
   ...>  ]
   iex> nutrition_entries = [
   ...>      %OpenBook.Fitness.NutritionEntry{
-  ...>        id: 21,
   ...>        nutrition_category_id: 1,
   ...>        user_id: 1,
   ...>        calorie_estimate: 300,
-  ...>        local_datetime: ~N[2023-02-28 16:39:29],
-  ...>        inserted_at: ~N[2023-03-01 00:39:29],
-  ...>        updated_at: ~N[2023-03-01 00:39:29]
+  ...>        local_datetime: ~N[2023-02-28 16:39:29]
   ...>      },
   ...>      %OpenBook.Fitness.NutritionEntry{
-  ...>        id: 20,
   ...>        nutrition_category_id: 1,
   ...>        user_id: 1,
   ...>        calorie_estimate: 500,
-  ...>        local_datetime: ~N[2023-02-28 09:52:13],
-  ...>        inserted_at: ~N[2023-02-28 17:52:13],
-  ...>        updated_at: ~N[2023-02-28 17:52:13]
+  ...>        local_datetime: ~N[2023-02-28 09:52:13]
   ...>      }
   ...>   ]
-  iex> OpenBook.Fitness.compress_nutrition_and_exercise_entries(%{ nutrition_entries: nutrition_entries, exercise_entries: exercise_entries })
+  iex> OpenBook.Fitness.compress_nutrition_and_exercise_entries(%{
+  ...>   nutrition_entries: nutrition_entries,
+  ...>   exercise_entries: exercise_entries
+  ...> })
   %{
       ~D[2023-02-27] => %{2 => %{
           measurement_by_exercise_category_id_and_intensity_tuple: %{{19, :light} => 55},

--- a/lib/open_book/fitness/exercise_category.ex
+++ b/lib/open_book/fitness/exercise_category.ex
@@ -23,45 +23,4 @@ defmodule OpenBook.Fitness.ExerciseCategory do
     |> validate_length(:name, min: 3)
     |> validate_inclusion(:measurement_kind, @measurement_kinds)
   end
-
-  ## Helpers
-
-  def human_readable_exercise_selection(exercise_category_name, intensity_level, exercise_measurement) do
-    hr_exercise_name = String.downcase(exercise_category_name)
-
-    if intensity_level do
-      hr_duration = human_readable_minutes(exercise_measurement)
-      # String interp here to allow either atom/string for intensity level.
-      hr_intensity_level = human_readable_intensity_level("#{intensity_level}")
-
-      "#{hr_duration} of #{hr_intensity_level} #{hr_exercise_name}"
-    else
-      "#{exercise_measurement} #{hr_exercise_name}"
-    end
-  end
-
-  # Private
-
-  defp human_readable_intensity_level("light"), do: "light"
-  defp human_readable_intensity_level("regular"), do: ""
-  defp human_readable_intensity_level("intense"), do: "intense"
-
-  defp human_readable_minutes(minutes) do
-    cond do
-      minutes < 60 ->
-        "#{minutes} minutes"
-
-      minutes == 60 ->
-        "an hour"
-
-      minutes < 120 ->
-        "an hour and #{rem(minutes, 60)} minutes"
-
-      rem(minutes, 60) == 0 ->
-        "#{div(minutes, 60)} hours"
-
-      true ->
-        "#{div(minutes, 60)} hours and #{rem(minutes, 60)} minutes"
-    end
-  end
 end

--- a/lib/open_book/human_readable.ex
+++ b/lib/open_book/human_readable.ex
@@ -1,0 +1,126 @@
+defmodule OpenBook.HumanReadable do
+  @moduledoc """
+  Misc. functions to help with making things human-readable.
+  """
+
+  @doc ~S"""
+  Create a human-readable list of things and-ed together.
+
+  ## Examples:
+
+    iex> OpenBook.HumanReadable.readable_and_list([])
+    ""
+
+    iex> OpenBook.HumanReadable.readable_and_list(["biking"])
+    "biking"
+
+    iex> OpenBook.HumanReadable.readable_and_list(["biking", "climbing"])
+    "biking and climbing"
+
+    iex> OpenBook.HumanReadable.readable_and_list(["biking", "climbing", "swimming"])
+    "climbing, swimming, and biking"
+  """
+  def readable_and_list([]), do: ""
+  def readable_and_list([single_string]), do: single_string
+  def readable_and_list([first_string, second_string]), do: "#{first_string} and #{second_string}"
+
+  def readable_and_list([first_string | rest_strings]) do
+    "#{Enum.join(rest_strings, ", ")}, and #{first_string}"
+  end
+
+  @doc ~S"""
+  Create a human-readable description of the calorie count.
+
+  ## Examples:
+
+    iex> OpenBook.HumanReadable.human_readable_calorie_description("I", nil)
+    "I did not record any nutrition."
+
+    iex> OpenBook.HumanReadable.human_readable_calorie_description("Charlie", 0)
+    "Charlie did not record any nutrition."
+
+    iex> OpenBook.HumanReadable.human_readable_calorie_description("Banafsheh", 500)
+    "Banafsheh had around 500 calories."
+  """
+  def human_readable_calorie_description(who, nil), do: "#{who} did not record any nutrition."
+  def human_readable_calorie_description(who, 0), do: "#{who} did not record any nutrition."
+  def human_readable_calorie_description(who, calorie_estimate), do: "#{who} had around #{calorie_estimate} calories."
+
+  @doc ~S"""
+  Create a human-readable description of the given exercises.
+
+  TODO(Arie): doctest
+  """
+  def human_readable_exercise_description(who, nil, _all_exercise_category_names_by_id), do: "#{who} did not exercise."
+
+  def human_readable_exercise_description(
+        who,
+        measurement_by_exercise_category_id_and_intensity_tuple,
+        all_exercise_category_names_by_id
+      ) do
+    if(measurement_by_exercise_category_id_and_intensity_tuple == %{}) do
+      human_readable_exercise_description(who, nil, all_exercise_category_names_by_id)
+    else
+      readable_exercise_segments =
+        Enum.map(measurement_by_exercise_category_id_and_intensity_tuple, fn {{exercise_category_id, intensity_level},
+                                                                              measurement} ->
+          exercise_category_name = Map.fetch!(all_exercise_category_names_by_id, exercise_category_id)
+          human_readable_exercise_selection(exercise_category_name, intensity_level, measurement)
+        end)
+
+      # TODO : move readable_and_list to backend.
+      readable_exercise_string = __MODULE__.readable_and_list(readable_exercise_segments)
+      "#{who} did #{readable_exercise_string}"
+    end
+  end
+
+  @doc """
+  Create a human-readable description of the given exercise selection.
+
+  ## Examples
+
+  iex> OpenBook.HumanReadable.human_readable_exercise_selection("Snowboarding", :light, 30)
+  "30 minutes of light snowboarding"
+
+  iex> OpenBook.HumanReadable.human_readable_exercise_selection("Snowboarding", "regular", 60)
+  "an hour of snowboarding"
+  """
+  def human_readable_exercise_selection(exercise_category_name, intensity_level, exercise_measurement) do
+    hr_exercise_name = String.downcase(exercise_category_name)
+
+    if intensity_level do
+      hr_duration = human_readable_minutes(exercise_measurement)
+      # String interp here to allow either atom/string for intensity level.
+      hr_intensity_level = human_readable_intensity_level("#{intensity_level}")
+
+      "#{hr_duration} of#{hr_intensity_level}#{hr_exercise_name}"
+    else
+      "#{exercise_measurement} #{hr_exercise_name}"
+    end
+  end
+
+  # Private
+
+  defp human_readable_intensity_level("light"), do: " light "
+  defp human_readable_intensity_level("regular"), do: " "
+  defp human_readable_intensity_level("intense"), do: " intense "
+
+  defp human_readable_minutes(minutes) do
+    cond do
+      minutes < 60 ->
+        "#{minutes} minutes"
+
+      minutes == 60 ->
+        "an hour"
+
+      minutes < 120 ->
+        "an hour and #{rem(minutes, 60)} minutes"
+
+      rem(minutes, 60) == 0 ->
+        "#{div(minutes, 60)} hours"
+
+      true ->
+        "#{div(minutes, 60)} hours and #{rem(minutes, 60)} minutes"
+    end
+  end
+end

--- a/lib/open_book/share.ex
+++ b/lib/open_book/share.ex
@@ -1,0 +1,15 @@
+defmodule OpenBook.Share do
+  import Ecto.Query
+
+  alias OpenBook.LittleLogger, as: LL
+  alias OpenBook.Repo
+  alias OpenBook.Share.DayStatsLink
+
+  # DB Queries
+
+  def get_day_stats_link_by_code!(code) do
+    LL.info_event("get_day_stats_link_by_code!", %{code: code})
+
+    Repo.get_by!(DayStatsLink, code: code)
+  end
+end

--- a/lib/open_book/share.ex
+++ b/lib/open_book/share.ex
@@ -1,9 +1,16 @@
 defmodule OpenBook.Share do
-  import Ecto.Query
-
   alias OpenBook.LittleLogger, as: LL
   alias OpenBook.Repo
   alias OpenBook.Share.DayStatsLink
+
+  # DB Mutations
+
+  def generate_new_day_stats_link!(by_user_id, date) do
+    LL.info_event("generate_new_day_stats_link!", %{by_user_id: by_user_id, date: date})
+
+    DayStatsLink.new_link_changeset(by_user_id, date)
+    |> Repo.insert!()
+  end
 
   # DB Queries
 

--- a/lib/open_book/share/day_stats_link.ex
+++ b/lib/open_book/share/day_stats_link.ex
@@ -2,6 +2,8 @@ defmodule OpenBook.Share.DayStatsLink do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias OpenBook.Accounts.VerificationCode
+
   schema "day_stats_links" do
     field :date, :date
     field :code, :string
@@ -10,10 +12,16 @@ defmodule OpenBook.Share.DayStatsLink do
     timestamps()
   end
 
+  def new_link_changeset(by_user_id, date) do
+    changeset(%__MODULE__{}, %{date: date})
+    |> put_change(:user_id, by_user_id)
+    |> put_change(:code, VerificationCode.generate_url_friendly_verification_code(human_friendly: false))
+  end
+
   @doc false
   def changeset(day_stats_link, attrs) do
     day_stats_link
-    |> cast(attrs, [:date, :code])
-    |> validate_required([:date, :code])
+    |> cast(attrs, [:date])
+    |> validate_required([:date])
   end
 end

--- a/lib/open_book/share/day_stats_link.ex
+++ b/lib/open_book/share/day_stats_link.ex
@@ -1,0 +1,19 @@
+defmodule OpenBook.Share.DayStatsLink do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "day_stats_links" do
+    field :date, :date
+    field :code, :string
+    field :user_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(day_stats_link, attrs) do
+    day_stats_link
+    |> cast(attrs, [:date, :code])
+    |> validate_required([:date, :code])
+  end
+end

--- a/lib/open_book_web/controllers/share_controller.ex
+++ b/lib/open_book_web/controllers/share_controller.ex
@@ -1,0 +1,56 @@
+defmodule OpenBookWeb.ShareController do
+  use OpenBookWeb, :controller
+
+  alias OpenBook.Accounts
+  alias OpenBook.DateHelpers
+  alias OpenBook.Fitness
+  alias OpenBook.LittleLogger, as: LL
+  alias OpenBook.Share
+
+  def share_day_stats(conn, %{"code" => code}) do
+    LL.info_event("share_viewed", %{code: code, is_new_user: conn.assigns.current_user == nil})
+
+    db_tasks = [
+      Task.async(fn -> Fitness.fetch_all_exercise_category_names_by_id() end),
+      Task.async(fn -> Share.get_day_stats_link_by_code!(code) end)
+    ]
+
+    [
+      all_exercise_category_names_by_id,
+      %{user_id: user_id, date: date}
+    ] = Task.await_many(db_tasks)
+
+    shared_user = Accounts.get_user!(user_id)
+
+    # TODO(Arie): This is inefficient as it fetches all [inc. unused] friend data, but, whatevs.
+    compressed_nutrition_and_exercise_entries =
+      user_id
+      |> Fitness.fetch_nutrition_and_exercise_entries_and_friends(%{
+        from_local_datetime: DateHelpers.naive_start_of_day(date),
+        to_local_datetime: DateHelpers.naive_end_of_day(date)
+      })
+      |> Fitness.compress_nutrition_and_exercise_entries()
+
+    shared_readable_calorie_description =
+      Fitness.get_readable_calorie_description(
+        compressed_nutrition_and_exercise_entries,
+        date,
+        user_id,
+        shared_user.display_name
+      )
+
+    shared_readable_exercise_description =
+      Fitness.get_readable_exercise_description(
+        compressed_nutrition_and_exercise_entries,
+        date,
+        user_id,
+        shared_user.display_name,
+        all_exercise_category_names_by_id
+      )
+
+    conn
+    |> assign(:shared_readable_calorie_description, shared_readable_calorie_description)
+    |> assign(:shared_readable_exercise_description, shared_readable_exercise_description)
+    |> render("share_day_stats.html")
+  end
+end

--- a/lib/open_book_web/controllers/share_controller.ex
+++ b/lib/open_book_web/controllers/share_controller.ex
@@ -22,7 +22,7 @@ defmodule OpenBookWeb.ShareController do
 
     shared_user = Accounts.get_user!(user_id)
 
-    # TODO(Arie): This is inefficient as it fetches all [inc. unused] friend data, but, whatevs.
+    # TODO(Arie): This is inefficient as it fetches all [unused] friend data, but, whatevs.
     compressed_nutrition_and_exercise_entries =
       user_id
       |> Fitness.fetch_nutrition_and_exercise_entries_and_friends(%{
@@ -36,7 +36,7 @@ defmodule OpenBookWeb.ShareController do
         compressed_nutrition_and_exercise_entries,
         date,
         user_id,
-        shared_user.display_name
+        "I"
       )
 
     shared_readable_exercise_description =
@@ -44,11 +44,13 @@ defmodule OpenBookWeb.ShareController do
         compressed_nutrition_and_exercise_entries,
         date,
         user_id,
-        shared_user.display_name,
+        "I",
         all_exercise_category_names_by_id
       )
 
     conn
+    |> assign(:date, date)
+    |> assign(:shared_user_display_name, shared_user.display_name)
     |> assign(:shared_readable_calorie_description, shared_readable_calorie_description)
     |> assign(:shared_readable_exercise_description, shared_readable_exercise_description)
     |> render("share_day_stats.html")

--- a/lib/open_book_web/live/exercise_log_live.ex
+++ b/lib/open_book_web/live/exercise_log_live.ex
@@ -9,6 +9,7 @@ defmodule OpenBookWeb.ExerciseLogLive do
 
   alias OpenBook.Accounts
   alias OpenBook.Fitness
+  alias OpenBook.HumanReadable
   alias OpenBook.LittleLogger, as: LL
 
   alias OpenBookWeb.HomeLive
@@ -186,7 +187,7 @@ defmodule OpenBookWeb.ExerciseLogLive do
         <p class="pt-0 pb-4 has-text-centered">
           <span>
             I did <%=
-              Fitness.human_readable_exercise_selection(
+              HumanReadable.human_readable_exercise_selection(
                 @selected_exercise_category.name,
                 @selected_intensity_level,
                 @selected_exercise_measurement

--- a/lib/open_book_web/live/home_live.ex
+++ b/lib/open_book_web/live/home_live.ex
@@ -29,6 +29,7 @@ defmodule OpenBookWeb.HomeLive do
     socket =
       socket
       |> assign(:user, user)
+      |> assign(:active_share_day_modal, false)
 
     {:ok, socket}
   end
@@ -95,6 +96,34 @@ defmodule OpenBookWeb.HomeLive do
     {:noreply, socket}
   end
 
+  def handle_event(
+    "activate_share_day_modal",
+    params,
+    socket
+  ) do
+    LL.info_event("handle_event", Map.merge(params, %{event_name: :activate_share_day_modal}))
+
+    socket =
+      socket
+      |> assign(:active_share_day_modal, true)
+
+    {:noreply, socket}
+  end
+
+  def handle_event(
+    "deactivate_share_day_modal",
+    params,
+    socket
+  ) do
+    LL.info_event("handle_event", Map.merge(params, %{event_name: :deactivate_share_day_modal}))
+
+    socket =
+      socket
+      |> assign(:active_share_day_modal, false)
+
+    {:noreply, socket}
+  end
+
   ## Render
 
   def render(assigns) do
@@ -110,6 +139,30 @@ defmodule OpenBookWeb.HomeLive do
         </div>
 
       <% "book" -> %>
+        <div class={ViewUtils.class_list("modal", %{"is-active" => @active_share_day_modal})}>
+          <div
+            class="modal-background"
+            phx-click="deactivate_share_day_modal"
+          >
+          </div>
+          <div class="modal-content">
+            <div class="box m-3">
+              Shares with close friends on/off the platform.
+
+              <div class="buttons are-small has-addons is-right">
+                <button class="button is-small is-rounded">
+                  <span class="icon">
+                    <i class="fas fa-link"></i>
+                  </span>
+
+                  <span>Copy Link</span>
+                </button>
+              </div>
+
+            </div>
+          </div>
+        </div>
+
         <div>
           <%= for day <- @book_daily_pages do %>
           <div class="mb-4 daily-entry">
@@ -194,6 +247,19 @@ defmodule OpenBookWeb.HomeLive do
                 </div>
               </div>
               <% end %>
+            </div>
+            <div class="buttons has-addons is-right">
+              <button
+                class="button is-small is-dark is-rounded b-0 aligned-right"
+                phx-click="activate_share_day_modal"
+              >
+                <span class="icon">
+                  <i class="fas fa-share-alt"></i>
+                </span>
+                <span>
+                  share
+                </span>
+              </button>
             </div>
           </div>
           <% end %>

--- a/lib/open_book_web/live/home_live.ex
+++ b/lib/open_book_web/live/home_live.ex
@@ -114,7 +114,7 @@ defmodule OpenBookWeb.HomeLive do
           <%= for day <- @book_daily_pages do %>
           <div class="mb-4 daily-entry">
             <div class="is-capitalized is-size-4 has-text-centered pb-4 has-text-weight-bold">
-              <%= DateHelpers.readable_date(DateTime.now!("America/Los_Angeles"), day.date, :human_relative_lingo_with_prefix) %>
+              <%= DateHelpers.readable_date(DateTime.now!("America/Los_Angeles"), day.date, :human_relative_lingo) %>
             </div>
 
             <div class="level is-mobile pb-0 mb-2">

--- a/lib/open_book_web/live/home_live.ex
+++ b/lib/open_book_web/live/home_live.ex
@@ -65,11 +65,10 @@ defmodule OpenBookWeb.HomeLive do
     socket =
       case selected_top_bar_tab do
         @top_bar_book_tab ->
-          socket =
-            socket
-            |> assign_new(:book_daily_pages, fn ->
-              get_book_daily_pages(current_user, Fitness.fetch_all_exercise_category_names_by_id())
-            end)
+          socket
+          |> assign_new(:book_daily_pages, fn ->
+            get_book_daily_pages(current_user, Fitness.fetch_all_exercise_category_names_by_id())
+          end)
 
         _ ->
           socket
@@ -100,10 +99,10 @@ defmodule OpenBookWeb.HomeLive do
   end
 
   def handle_event(
-    "activate_share_day_modal",
-    params = %{"date" => date},
-    socket
-  ) do
+        "activate_share_day_modal",
+        params = %{"date" => date},
+        socket
+      ) do
     LL.info_event("handle_event", Map.merge(params, %{event_name: :activate_share_day_modal}))
 
     current_user = socket.assigns.user
@@ -119,10 +118,10 @@ defmodule OpenBookWeb.HomeLive do
   end
 
   def handle_event(
-    "deactivate_share_day_modal",
-    params,
-    socket
-  ) do
+        "deactivate_share_day_modal",
+        params,
+        socket
+      ) do
     LL.info_event("handle_event", Map.merge(params, %{event_name: :deactivate_share_day_modal}))
 
     socket =

--- a/lib/open_book_web/router.ex
+++ b/lib/open_book_web/router.ex
@@ -22,7 +22,15 @@ defmodule OpenBookWeb.Router do
     plug(:accepts, ["json"])
   end
 
-  # Logged out routes.
+  # Login-irrelevant-routes.
+  scope "/", OpenBookWeb do
+    pipe_through([:browser])
+
+    # Avoid live-view for shares so it can be unfurled nicely in chats + load as fast as possibl
+    get("/share/day/:code", ShareController, :share_day_stats)
+  end
+
+  # Logged-out-only routes. Will redirect if logged in.
   scope "/", OpenBookWeb do
     pipe_through([:browser, :redirect_if_logged_in])
 
@@ -30,7 +38,7 @@ defmodule OpenBookWeb.Router do
     get("/login/:code", SessionController, :login_through_url_with_verification_code)
   end
 
-  # Logged in routes.
+  # Logged-in-only routes. Will redirect if logged out.
   scope "/", OpenBookWeb do
     pipe_through([:browser, :authenticate_user])
 

--- a/lib/open_book_web/templates/page/index.html.heex
+++ b/lib/open_book_web/templates/page/index.html.heex
@@ -2,9 +2,9 @@
   <div class="hero-body">
     <div>
       <p class="title is-size-4 has-text-black">
-        Stay fit with friends.
+        Stay fit with close friends.
       </p>
-      <p class="subtitle is-size-5 has-text-dark">
+      <p class="subtitle is-size-6 has-text-dark">
         It's your story. And it's personal.
       </p>
     </div>

--- a/lib/open_book_web/templates/share/share_day_stats.html.heex
+++ b/lib/open_book_web/templates/share/share_day_stats.html.heex
@@ -1,0 +1,1 @@
+TODO(Arie): Render share data.

--- a/lib/open_book_web/templates/share/share_day_stats.html.heex
+++ b/lib/open_book_web/templates/share/share_day_stats.html.heex
@@ -1,8 +1,5 @@
 <div class="level is-mobile p-3">
     <div class="level-left">
-        <div class="level-item">
-
-        </div>
     </div>
 
     <div class="level-right has_text_dark_blue">
@@ -73,3 +70,16 @@
         </div>
     </div>
 </div>
+
+<%= if @current_user  do %>
+    <div class="new_entry_footer">
+        <div class="buttons is-right pb-4 pr-4">
+            <%= link(to: "/home", class: "button is-light has_border_grey has_text_dark_blue b-0") do %>
+            <span class="icon">
+                <i class="fas fa-book"></i>
+            </span>
+            <span>Back to my OpenBook</span>
+            <% end %>
+        </div>
+    </div>
+<% end %>

--- a/lib/open_book_web/templates/share/share_day_stats.html.heex
+++ b/lib/open_book_web/templates/share/share_day_stats.html.heex
@@ -1,4 +1,4 @@
-<div class="level is-mobile p-3">
+<div class="level is-mobile p-3 mb-3">
     <div class="level-left">
     </div>
 
@@ -10,10 +10,6 @@
                 Shared by <%= @shared_user_display_name %>
             </span>
     </div>
-</div>
-
-<div class="ml-5 mr-5 title is-6">
- This is what I call a good fucking day.
 </div>
 
 <div class="daily-entry ml-5 mr-5">

--- a/lib/open_book_web/templates/share/share_day_stats.html.heex
+++ b/lib/open_book_web/templates/share/share_day_stats.html.heex
@@ -1,1 +1,75 @@
-TODO(Arie): Render share data.
+<div class="level is-mobile p-3">
+    <div class="level-left">
+        <div class="level-item">
+
+        </div>
+    </div>
+
+    <div class="level-right has_text_dark_blue">
+            <span class="icon">
+                <i class="fas fa-retweet"></i>
+            </span>
+            <span class="has-text-weight-semibold pl-1">
+                Shared by <%= @shared_user_display_name %>
+            </span>
+    </div>
+</div>
+
+<div class="ml-5 mr-5 title is-6">
+ This is what I call a good fucking day.
+</div>
+
+<div class="daily-entry ml-5 mr-5">
+    <div class="title is-4 has-text-centered is-capitalized">
+        <% # TODO(Arie): timezone-support %>
+        <%= OpenBook.DateHelpers.readable_date(DateTime.now!("America/Los_Angeles"), @date, :human_relative_lingo) %>
+    </div>
+
+    <div class="level is-mobile pb-0 mb-2">
+        <div class="level-left">
+        <div class="level-item">
+            <span class="has-text-weight-semibold">
+            Nutrition
+            </span>
+        </div>
+        </div>
+
+        <div class="level-item ml-3" style="border-bottom: 1px #2f364d solid;"></div>
+
+        <div class="level-right has_text_dark_blue">
+        <span class="icon">
+            <i class="fas fa-utensils"></i>
+        </span>
+        </div>
+    </div>
+
+    <p class="pt-0 pb-2">
+        <div class="pb-4" style="line-height: 20px;">
+            <%= @shared_readable_calorie_description %>
+        </div>
+    </p>
+
+    <div class="level is-mobile pt-5 pb-0">
+        <div class="level-left">
+        <div class="level-item">
+        <span class="has-text-weight-semibold">
+            Exercise
+            </span>
+        </div>
+        </div>
+
+        <div class="level-item ml-3" style="border-bottom: 1px #2f364d solid;"></div>
+
+        <div class="level-right">
+        <span class="icon">
+            <i class="fas fa-dumbbell"></i>
+        </span>
+        </div>
+    </div>
+
+    <div class="pt-0 pb-2">
+        <div class="pb-4" style="line-height: 20px;">
+            <%= @shared_readable_exercise_description %>
+        </div>
+    </div>
+</div>

--- a/lib/open_book_web/templates/share/share_day_stats.html.heex
+++ b/lib/open_book_web/templates/share/share_day_stats.html.heex
@@ -74,7 +74,7 @@
             <span class="icon">
                 <i class="fas fa-book"></i>
             </span>
-            <span>Back to my OpenBook</span>
+            <span>My OpenBook</span>
             <% end %>
         </div>
     </div>

--- a/lib/open_book_web/view_utils.ex
+++ b/lib/open_book_web/view_utils.ex
@@ -23,29 +23,4 @@ defmodule OpenBookWeb.ViewUtils do
       end
     end)
   end
-
-  @doc ~S"""
-  Create a human-readable list of things and-ed together.
-
-  ## Examples:
-
-    iex> OpenBookWeb.ViewUtils.readable_and_list([])
-    ""
-
-    iex> OpenBookWeb.ViewUtils.readable_and_list(["biking"])
-    "biking"
-
-    iex> OpenBookWeb.ViewUtils.readable_and_list(["biking", "climbing"])
-    "biking and climbing"
-
-    iex> OpenBookWeb.ViewUtils.readable_and_list(["biking", "climbing", "swimming"])
-    "climbing, swimming, and biking"
-  """
-  def readable_and_list([]), do: ""
-  def readable_and_list([single_string]), do: single_string
-  def readable_and_list([first_string, second_string]), do: "#{first_string} and #{second_string}"
-
-  def readable_and_list([first_string | rest_strings]) do
-    "#{Enum.join(rest_strings, ", ")}, and #{first_string}"
-  end
 end

--- a/lib/open_book_web/views/share_view.ex
+++ b/lib/open_book_web/views/share_view.ex
@@ -1,0 +1,3 @@
+defmodule OpenBookWeb.ShareView do
+  use OpenBookWeb, :view
+end

--- a/priv/repo/migrations/20230228225951_create_day_stats_links.exs
+++ b/priv/repo/migrations/20230228225951_create_day_stats_links.exs
@@ -1,0 +1,16 @@
+defmodule OpenBook.Repo.Migrations.CreateDayStatsLinks do
+  use Ecto.Migration
+
+  def change do
+    create table(:day_stats_links) do
+      add :date, :date, null: false
+      add :code, :string, null: false
+      add :user_id, references(:users, on_delete: :nothing), null: false
+
+      timestamps()
+    end
+
+    create index(:day_stats_links, [:user_id])
+    create index(:day_stats_links, [:code])
+  end
+end

--- a/test/open_book/date_helpers_test.exs
+++ b/test/open_book/date_helpers_test.exs
@@ -1,0 +1,4 @@
+defmodule OpenBook.DateHelpersTest do
+  use ExUnit.Case, async: true
+  doctest OpenBook.DateHelpers
+end

--- a/test/open_book/fitness_test.exs
+++ b/test/open_book/fitness_test.exs
@@ -1,0 +1,4 @@
+defmodule OpenBookWeb.FitnessTest do
+  use ExUnit.Case, async: true
+  doctest OpenBook.Fitness
+end

--- a/test/open_book/human_readable_test.exs
+++ b/test/open_book/human_readable_test.exs
@@ -1,0 +1,4 @@
+defmodule OpenBookWeb.HumanReadableTest do
+  use ExUnit.Case, async: true
+  doctest OpenBook.HumanReadable
+end

--- a/test/open_book_web/controllers/page_controller_test.exs
+++ b/test/open_book_web/controllers/page_controller_test.exs
@@ -3,6 +3,6 @@ defmodule OpenBookWeb.PageControllerTest do
 
   test "GET /", %{conn: conn} do
     conn = get(conn, "/")
-    assert html_response(conn, 200) =~ "Stay fit with friends"
+    assert html_response(conn, 200) =~ "Stay fit with close friends"
   end
 end


### PR DESCRIPTION
### Description

The simplest version of sharing a single day with others.

Future TODO:
 - Allow sign up as friend through shared link
 - Allow sharing just exercise/nutrition
 - Allow sharing multiple days (?)
 - Show shared data when generating share-link on `HomeLive` tab, currently just creates the link without a preview.

### Screenshots

New share button:
<img width="413" alt="image" src="https://user-images.githubusercontent.com/9031171/222234938-45951510-97c7-4aaf-87fa-7bc7ae77feaf.png">

Generates link (no preview):
<img width="399" alt="image" src="https://user-images.githubusercontent.com/9031171/222235077-3d20298c-f37d-4529-b0d5-f5fe53947507.png">

Simple rendering for users logged out / in:
<img width="451" alt="image" src="https://user-images.githubusercontent.com/9031171/222234996-4c612fef-2d8f-4475-b132-c2c6b33e5750.png">

